### PR TITLE
Fix retry memory. More descriptive job name. Better final message

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ This is an outline of the procedure to release the container to [Github Containe
    docker image push ghcr.io/dkfz-odcf/nf-bam2fastq:$versionTag
    ```
 
+## Continuous Delivery
+
+For all commits with a tag that follows the pattern `\d+\.\d+\.\d+` the job containers are automatically pushed to [Github Container Registry](https://github.com/orgs/DKFZ-ODCF/packages) of the "ODCF" organization. Version tags should only be added to commits on the `master` branch, although currently no automatic rule enforces this.
+
 ## Release Notes
 
 * 1.0.0 (June 15., 2021)

--- a/main.nf
+++ b/main.nf
@@ -98,7 +98,7 @@ process bamToFastq {
     cpus 1
     // The biobambam paper states something like 133 MB.
     memory 1.GB
-    time { 48.hours * (2**task.attempt - 1) }
+    time { 48.hours * 2**(task.attempt - 1) }
     maxRetries 2
 
     publishDir params.outputDir, enabled: !params.sortFastqs
@@ -150,7 +150,7 @@ process nameSortUnpairedFastqs {
     cpus { params.sortThreads + (params.compressIntermediateFastqs ? params.compressorThreads : 0 )  }
     memory { (sortMemory + 100.MB) * params.sortThreads * 1.2 }
     // TODO Make runtime dependent on file-size.
-    time { 24.hour * (2**task.attempt - 1) }
+    time { 24.hour * 2**(task.attempt - 1) }
     maxRetries 2
 
     publishDir params.outputDir
@@ -187,7 +187,7 @@ process nameSortPairedFastqs {
     cpus { params.sortThreads + (params.compressIntermediateFastqs ? params.compressorThreads * 2 : 0) }
     memory { (sortMemory + 100.MB) * params.sortThreads * 1.2 }
     // TODO Make runtime dependent on file-size.
-    time { 24.hours * (2**task.attempt - 1) }
+    time { 24.hours * 2**(task.attempt - 1) }
     maxRetries 2
 
     publishDir params.outputDir
@@ -241,7 +241,7 @@ void checkParameters(parameters, List<String> allowedParameters) {
     }
 }
 
-
+// Convert the configured sort memory from Nextflows MemoryUnit to a string for the `sort` tool.
 String toSortMemoryString(MemoryUnit mem) {
     def splitted = mem.toString().split(" ")
     String size = splitted[0]

--- a/main.nf
+++ b/main.nf
@@ -274,5 +274,6 @@ String toSortMemoryString(MemoryUnit mem) {
 
 
 workflow.onComplete {
-    log.info "Success!"
+    println "Workflow run $workflow.runName completed at $workflow.complete with status " +
+            "${ workflow.success ? 'success' : 'failure' }"
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,7 @@ profiles {
             export BIOBAMBAM_BAM2FASTQ_BINARY=bamtofastq
             """
         }
-
+        conda.cacheDir = "${projectDir}/cache/conda"
     }
 
     docker {
@@ -63,7 +63,7 @@ profiles {
     singularity {
         process.container = 'nf-bam2fastq_1.0.0.sif'
         singularity.enabled = true
-        singularity.cacheDir = "${projectDir}"
+        singularity.cacheDir = "${projectDir}/cache/singularity"
         // The singularity containers are stored in the workflow-directory
         singularity.autoMounts = true
     }
@@ -104,6 +104,6 @@ profiles {
  * https://www.nextflow.io/docs/latest/config.html?highlight=jobname#scope-executor
  */
 executor {
-    jobName = { "$task.name - $task.hash" }
+    jobName = { "nf-bam2fastq - $task.name - $task.hash" }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -98,3 +98,12 @@ profiles {
     }
 
 }
+
+/**  Use the following to configure e.g. submission limits, job-names, etc. for the executor. See
+ *
+ * https://www.nextflow.io/docs/latest/config.html?highlight=jobname#scope-executor
+ */
+executor {
+    jobName = { "$task.name - $task.hash" }
+}
+


### PR DESCRIPTION
* Memory calculation as exponential backoff was incorrect
* Job names now contain workflow name and job/task hash. Run name seems currently not possible to include there (due to a possible bug in Nextflow).
* The end message when the workflow runs now reports whether the workflow execution failed (instead of always "success").